### PR TITLE
Update payment-initiation-openapi.json

### DIFF
--- a/pkg/schema/spec/v4.0.0/payment-initiation-openapi.json
+++ b/pkg/schema/spec/v4.0.0/payment-initiation-openapi.json
@@ -10401,7 +10401,8 @@
                   "ACWP",
                   "ACCC",
                   "BLCK",
-                  "RJCT"
+                  "RJCT",
+                  "RCVD"
                 ]
               },
               "StatusUpdateDateTime": {

--- a/pkg/schema/spec/v4.0.0/payment-initiation-openapi.json
+++ b/pkg/schema/spec/v4.0.0/payment-initiation-openapi.json
@@ -11716,7 +11716,8 @@
                   "ACWP",
                   "ACCC",
                   "BLCK",
-                  "RJCT"
+                  "RJCT",
+                  "RCVD"
                 ]
               },
               "StatusUpdateDateTime": {


### PR DESCRIPTION
Test ID: OB-400-DOP-102300
Ref URI: https://openbankinguk.github.io/read-write-api-site3/v4.0/profiles/payment-initiation-api-profile.html Detail: Check PISP can retrieve the International Scheduled Payment. Errors:
Test Case message: Validate: Validate error response: response body doesn't match the schema: Error at "/Data/Status": value is not one of the allowed values Schema: { "description": "Specifies the status of the payment order resource.", "enum": [ "PDNG", "ACTC", "PATC", "ACCP", "ACFC", "ACSP", "ACWC", "ACSC", "ACWP", "ACCC", "BLCK", "RJCT" ], "type": "string" } Value: "RCVD" Endpoint response (200): {"Data":{"Initiation":{"InstructionIdentification":"a9217aeb148c4c9c9b6599d89720ffdb","EndToEndIdentification":"e2e-internat-sched-pay","InstructedAmount":{"Amount":"1.00","Currency":"GBP"},"CreditorAccount":{"Identification":"DE98500700103295643643","Name":"ACMEInc","SchemeName":"UK.OBIE.IBAN"},"CurrencyOfTransfer":"GBP","RequestedExecutionDateTime":"2025-12-30T23:00:00"},"ConsentId":"qjnhniltwlz76j7q","StatusUpdateDateTime":"2025-03-04T05:50:31.000+05:30","CreationDateTime":"2025-03-04T05:50:31.000+05:30","Debtor":{"Name":""},"Status":"RCVD","InternationalScheduledPaymentId":"8559668442222134309"},"Links":{"Self":{},"Meta":{}} Analysis : OBWriteInternationalResponse5 doesnt have OBWriteInternationalResponse5 > Status (ExternalPaymentTransactionStatus1Code) doesnt have RCVD value. As per specs it is present in External_Codesets v2 csv file (ExternalPaymentTransactionStatus1Code)