### PR TITLE
Fix open tab on run

### DIFF
--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -42,7 +42,7 @@ module.exports = {
       },
     },
     // open: 'Google Chrome',
-    open: false,  // disabling due to opening on the wrong page.
+    open: false, // disabling due to opening on the wrong page.
   },
 
   // https://cli.vuejs.org/config/#runtimecompiler
@@ -56,11 +56,9 @@ module.exports = {
     // * https://cli.vuejs.org/guide/webpack.html#replacing-loaders-of-a-rule
     // * https://github.com/vuejs/vue-cli/issues/3215
 
-    config.module.rule('fonts').use('url-loader').tap((opts) =>
-        Object.assign(opts, { limit: 0 }));
+    config.module.rule('fonts').use('url-loader').tap(opts => Object.assign(opts, { limit: 0 }));
 
-    config.module.rule('images').use('url-loader').tap((opts) =>
-        Object.assign(opts, { limit: 0 }));
+    config.module.rule('images').use('url-loader').tap(opts => Object.assign(opts, { limit: 0 }));
 
     // Copy `ReDoc` (https://github.com/Rebilly/ReDoc) to `/static/redoc/bundles/redoc.standalone.js`
     // so that `pkg/server/swagger_handlers.go` can use it as the `RedocURL`.

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -42,7 +42,7 @@ module.exports = {
       },
     },
     // open: 'Google Chrome',
-    open: false  // disabling due to opening on the wrong page.
+    open: false,  // disabling due to opening on the wrong page.
   },
 
   // https://cli.vuejs.org/config/#runtimecompiler

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -41,7 +41,8 @@ module.exports = {
         xfwd: true,
       },
     },
-    open: 'Google Chrome',
+    // open: 'Google Chrome',
+    open: false  // disabling due to opening on the wrong page.
   },
 
   // https://cli.vuejs.org/config/#runtimecompiler

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -57,13 +57,11 @@ module.exports = {
     // * https://github.com/vuejs/vue-cli/issues/3215
 
     config.module.rule('fonts').use('url-loader').tap((opts) => {
-      const options = Object.assign(opts, { limit: 0 });
-      return options;
+      return Object.assign(opts, { limit: 0 });
     });
 
     config.module.rule('images').use('url-loader').tap((opts) => {
-      const options = Object.assign(opts, { limit: 0 });
-      return options;
+      return Object.assign(opts, { limit: 0 });
     });
 
     // Copy `ReDoc` (https://github.com/Rebilly/ReDoc) to `/static/redoc/bundles/redoc.standalone.js`

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -56,13 +56,11 @@ module.exports = {
     // * https://cli.vuejs.org/guide/webpack.html#replacing-loaders-of-a-rule
     // * https://github.com/vuejs/vue-cli/issues/3215
 
-    config.module.rule('fonts').use('url-loader').tap((opts) => {
-      return Object.assign(opts, { limit: 0 });
-    });
+    config.module.rule('fonts').use('url-loader').tap((opts) =>
+        Object.assign(opts, { limit: 0 }));
 
-    config.module.rule('images').use('url-loader').tap((opts) => {
-      return Object.assign(opts, { limit: 0 });
-    });
+    config.module.rule('images').use('url-loader').tap((opts) =>
+        Object.assign(opts, { limit: 0 }));
 
     // Copy `ReDoc` (https://github.com/Rebilly/ReDoc) to `/static/redoc/bundles/redoc.standalone.js`
     // so that `pkg/server/swagger_handlers.go` can use it as the `RedocURL`.


### PR DESCRIPTION
I disabled the automatically opening browser tab to the wrong URL (`https://localhost:8080`) when running the FCS. I tried setting it to the correct URL using `https://0.0.0.0:8443` however, it would open on inconsistent ports and require manual user approval to bypass the HTTPS certificate. So, it is easier to just click on the `https://0.0.0.0:8443` URL that is output in the `make run` logs and it will open the correct page for running the tool without user certificate bypass approval.

Additionally, I removed some redundant variable declaration in 1 line return functions.