### PR TITLE
Update cVRP-v4.0-generic-discovery.json

### DIFF
--- a/pkg/discovery/templates/cVRP-v4.0-generic-discovery.json
+++ b/pkg/discovery/templates/cVRP-v4.0-generic-discovery.json
@@ -13,8 +13,8 @@
           "schemaVersion": "https://raw.githubusercontent.com/OpenBankingUK/Commercial-VRP-API-Spec/refs/heads/main/OpenAPI/cvrp-openapi.json",
           "manifest": "file://manifests/cVRP_4.0_variable_recurring_payments.json"
         },
-        "openidConfigurationUri": "https://YOUR URL HERE/.well-known/openid-configuration",
-        "resourceBaseUri": "https://YOUR URL HERE/open-banking/v4.0/pisp",
+        "openidConfigurationUri": "",
+        "resourceBaseUri": "",
         "endpoints": [
           {
             "method": "POST",


### PR DESCRIPTION
Removed example values for openidConfigurationUri and resourceBaseUri as these were causing tests to fail