### PR TITLE
Replace regex tooling with regexp2 to support lookahead/lookbehind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=

--- a/pkg/manifest/script.go
+++ b/pkg/manifest/script.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/OpenBankingUK/conformance-suite/pkg/schema"
 	"github.com/blang/semver/v4"
+	"github.com/dlclark/regexp2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -252,7 +253,7 @@ func convertInputStringToArray(value string) []string {
 	return strings.Split(value, ",")
 }
 
-var fnReplacementRegex = regexp.MustCompile(`[^\$fn:]?\$fn:([\w|_]*)\(([\w,\s-,:,\.]*)\)`)
+var fnReplacementRegex = regexp2.MustCompile(`(?<!\$)\$fn:([\w_]*)\(([\w,\s\-:,\.]*)\)`, regexp2.None)
 
 func (s *Script) processParameters(refs *References, resources *model.Context) (*model.Context, error) {
 	localCtx := model.Context{}
@@ -317,17 +318,18 @@ func isFunction(param string) bool {
 }
 
 func fnNameAndArgs(param string) (string, []string, error) {
-	fnNameAndArgs := fnReplacementRegex.FindStringSubmatch(param)
-	if fnNameAndArgs == nil {
+	match, err := fnReplacementRegex.FindStringMatch(param)
+	if err != nil || match == nil {
 		return "", nil, errors.New("function name format error processing " + param)
 	}
+	groups := match.Groups()
 	fnArgs := []string{}
-	// fn has some parameters
-	if len(fnNameAndArgs) > 2 && fnNameAndArgs[2] != "" {
-		fnArgs = strings.Split(fnNameAndArgs[2], ",")
+	// fn has some parameters (groups[0]=full match, groups[1]=name, groups[2]=args)
+	if len(groups) > 2 && groups[2].String() != "" {
+		fnArgs = strings.Split(groups[2].String(), ",")
 	}
 
-	return fnNameAndArgs[1], fnArgs, nil
+	return groups[1].String(), fnArgs, nil
 }
 
 func (r *Reference) getValue() string {

--- a/pkg/model/match.go
+++ b/pkg/model/match.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/dlclark/regexp2"
 
 	"github.com/OpenBankingUK/conformance-suite/pkg/tracer"
 	"github.com/tidwall/gjson"
@@ -407,15 +408,18 @@ func checkHeaderRegexContext(m *Match, tc *TestCase) (bool, error) {
 		}
 	}
 	headerValue := tc.Header.Get(actualHeader)
-	regex, err := regexp.Compile(m.Regex)
+	regex, err := regexp2.Compile(m.Regex, regexp2.None)
 	if err != nil {
 		return false, err
 	}
-	result := regex.FindStringSubmatch(headerValue)
-	if len(result) < 2 {
+	match, err := regex.FindStringMatch(headerValue)
+	if err != nil {
+		return false, err
+	}
+	if match == nil || len(match.Groups()) < 2 {
 		return false, m.AppErr(fmt.Sprintf("Header Regex Context Match Failed - regex (%s) failed to find anything on Header (%s) value (%s)", m.Regex, m.Header, headerValue))
 	}
-	m.Result = result[1]
+	m.Result = match.Groups()[1].String()
 	return success, nil
 }
 
@@ -431,12 +435,15 @@ func checkHeaderRegex(m *Match, tc *TestCase) (bool, error) {
 	}
 
 	headerValue := tc.Header.Get(actualHeader)
-	regex, err := regexp.Compile(m.Regex)
+	regex, err := regexp2.Compile(m.Regex, regexp2.None)
 	if err != nil {
 		return false, err
 	}
 
-	success = regex.MatchString(headerValue)
+	success, err = regex.MatchString(headerValue)
+	if err != nil {
+		return false, err
+	}
 
 	if !success {
 		return false, m.AppErr(fmt.Sprintf("Header Regex Match Failed - regex (%s) failed on Header (%s) Value (%s)", m.Regex, m.Header, m.Value))
@@ -456,18 +463,24 @@ func checkHeaderPresent(m *Match, tc *TestCase) (bool, error) {
 }
 
 func checkBodyRegex(m *Match, tc *TestCase) (bool, error) {
-	regex, err := regexp.Compile(m.Regex)
+	regex, err := regexp2.Compile(m.Regex, regexp2.None)
 	if err != nil {
 		return false, err
 	}
-	success := regex.MatchString(tc.Body)
+	success, err := regex.MatchString(tc.Body)
+	if err != nil {
+		return false, err
+	}
 	if !success {
 		return false, m.AppErr(fmt.Sprintf("Body Regex Match Failed - regex (%s) failed on Body", m.Regex))
 	}
 	if len(m.ContextName) > 0 {
-		regexMatch := regex.FindStringSubmatch(tc.Body)
-		if len(regexMatch) > 0 {
-			m.Result = regexMatch[0]
+		regexMatch, err := regex.FindStringMatch(tc.Body)
+		if err != nil {
+			return false, err
+		}
+		if regexMatch != nil {
+			m.Result = regexMatch.String()
 		}
 	}
 	return success, nil
@@ -571,12 +584,15 @@ func checkBodyJSONRegex(m *Match, tc *TestCase) (bool, error) {
 	if len(result.String()) == 0 {
 		return false, m.AppErr(fmt.Sprintf("JSON Regex Match Failed - no field present for pattern (%s)", m.JSON))
 	}
-	regex, err := regexp.Compile(m.Regex)
+	regex, err := regexp2.Compile(m.Regex, regexp2.None)
 	if err != nil {
 		return false, err
 	}
 
-	success := regex.MatchString(result.String())
+	success, err := regex.MatchString(result.String())
+	if err != nil {
+		return false, err
+	}
 	if !success {
 		return false, m.AppErr(fmt.Sprintf("JSON Regex Match Failed - selected field (%s) does not match regex (%s)", result.String(), m.Regex))
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/OpenBankingUK/conformance-suite/pkg/authentication"
 	"github.com/OpenBankingUK/conformance-suite/pkg/schema"
 	"github.com/OpenBankingUK/conformance-suite/pkg/schemaprops"
+	"github.com/dlclark/regexp2"
 
 	"github.com/sirupsen/logrus"
 
@@ -621,7 +621,7 @@ func replaceContextField(source string, ctx *Context) (string, error) {
 	return result, nil
 }
 
-var singleDollarRegex = regexp.MustCompile(`[^\$]?\$([\w|\-|_]*)`)
+var singleDollarRegex = regexp2.MustCompile(`(?<!\$)\$([\w\-_]*)`, regexp2.None)
 
 // GetReplacementField examines the input string and returns the first character
 // sequence beginning with '$' and ending with whitespace. '$$' sequence acts as an escape value
@@ -632,11 +632,15 @@ func getReplacementField(value string) (string, bool) {
 	if !isReplacement {
 		return value, false
 	}
-	result := singleDollarRegex.FindStringSubmatch(value)
-	if result == nil {
+	match, err := singleDollarRegex.FindStringMatch(value)
+	if err != nil || match == nil {
 		return "", false
 	}
-	return result[len(result)-1], true
+	groups := match.Groups()
+	if len(groups) < 2 {
+		return "", false
+	}
+	return groups[1].String(), true
 }
 
 func isReplacementField(value string) bool {


### PR DESCRIPTION
## Summary

Resolves the Jira ticket: **Replace regex tooling with one that supports lookahead/lookbehind**.

Go's standard `regexp` package uses the RE2 engine which explicitly rejects lookahead and lookbehind syntax. This caused a hard failure when importing JSON spec or test-case files containing such patterns — most notably the `x-idempotency-key` header regex.

## Changes

| File | Change |
|---|---|
| `go.mod` / `go.sum` | Add `github.com/dlclark/regexp2 v1.11.5` (PCRE-compatible engine) |
| `pkg/model/match.go` | Replace all `regexp.Compile(m.Regex)` calls with `regexp2.Compile` — any `"regex"` field in a JSON test-case file can now contain lookahead/lookbehind |
| `pkg/model/model.go` | Replace `singleDollarRegex` workaround `[^\$]?\$...` with a proper negative lookbehind `(?<!\$)\$...` |
| `pkg/manifest/script.go` | Replace `fnReplacementRegex` workaround with a proper negative lookbehind |

## Acceptance Criteria

- [x] JSON files can be imported without removing or modifying regex patterns that use lookahead/lookbehind
- [x] All existing tests pass (`go test ./...`)
- [x] Project builds cleanly (`go build ./...`)
