### PR TITLE
fix: correct test case ID OB-400-DOP-101503 in v1.9.6 release notes

### DIFF
--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -32,7 +32,7 @@
 
 ### Removed
 
-- Removed `OB-301-DOP-1015002` (v3) and `OB-400-DOP-1015002` (v4) tests as these are replaced by test ID `OB-301-DOP-1015003` and `OB-400-DOP-1015003` respectively.
+- Removed `OB-301-DOP-1015002` (v3) and `OB-400-DOP-1015002` (v4) tests as these are replaced by test ID `OB-301-DOP-1015003` and `OB-400-DOP-101503` respectively.
 
 ## [1.9.6-beta5] - 30/12/2025
 

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -21,7 +21,7 @@
 - Added extra assertion checks for `ReadAccountsDetail`, `ReadBeneficiariesDetail`, and `ReadTransactionsDetail` tests for v3 and v4
 - added support for Commercial VRP (cVRP)
 - Add enhanced logging for test case authorization and execution
-- Added tests `OB-301-DOP-1015003` and `OB-400-DOP-1015003` which validate the following:
+- Added tests `OB-301-DOP-1015003` and `OB-400-DOP-101503` which validate the following:
   - OB-301-DOP-1015003 (v3): validates that `NumberOfPayments` and `FinalPaymentDateTime` are correctly rejected when included in a consent payload at the same time.
   - OB-400-DOP-101500 (v4): validates that `CountPerPeriod` and `FinalPaymentDateTime` are correctly rejected when included in a consent payload at the same time.
 

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -1,5 +1,11 @@
 # Release history
 
+## [unreleased]
+
+## Fixed
+
+- Fixed incorrect test case ID references in v1.9.6 release notes from `OB-400-DOP-1015003` to `OB-400-DOP-101503`
+
 ## [1.9.7] - 05/03/2026
 
 ## Changed

--- a/docs/releases/v1.9.6.md
+++ b/docs/releases/v1.9.6.md
@@ -9,7 +9,7 @@ This release incorporates the following changes:
 - Added extra assertion checks for `ReadAccountsDetail`, `ReadBeneficiariesDetail`, and `ReadTransactionsDetail` tests for v3 and v4
 - added support for Commercial VRP (cVRP)
 - Add enhanced logging for test case authorization and execution
-- Added tests `OB-301-DOP-1015003` and `OB-400-DOP-1015003` which validate the following:
+- Added tests `OB-301-DOP-1015003` and `OB-400-DOP-101503` which validate the following:
   - OB-301-DOP-1015003 (v3): validates that `NumberOfPayments` and `FinalPaymentDateTime` are correctly rejected when included in a consent payload at the same time.
   - OB-400-DOP-101500 (v4): validates that `CountPerPeriod` and `FinalPaymentDateTime` are correctly rejected when included in a consent payload at the same time.
 

--- a/docs/releases/v1.9.6.md
+++ b/docs/releases/v1.9.6.md
@@ -19,7 +19,7 @@ This release incorporates the following changes:
 
 ### Removed
 
-- Removed `OB-301-DOP-1015002` (v3) and `OB-400-DOP-1015002` (v4) tests as these are replaced by test ID `OB-301-DOP-1015003` and `OB-400-DOP-1015003` respectively.
+- Removed `OB-301-DOP-1015002` (v3) and `OB-400-DOP-1015002` (v4) tests as these are replaced by test ID `OB-301-DOP-1015003` and `OB-400-DOP-101503` respectively.
 
 ## Download
 


### PR DESCRIPTION
## Summary

Fixes incorrect test case ID references in the v1.9.6 release notes.

## Changes

- Corrects `OB-400-DOP-1015003` → `OB-400-DOP-101503` in two places within `docs/releases/v1.9.6.md` and `docs/releases/releases.md`
  - In the "Added tests" line under Changed
  - In the "Removed" section describing replaced test IDs
- Adds an [unreleased] entry to `releases.md` documenting this fix

## Type of change

- [x] Bug fix (documentation correction — wrong test case ID in release notes)
