### PR TITLE
fix: add Content-Type application/json to standing order negative consent tests (v3.1 & v4.0)

### DIFF
--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -8,6 +8,7 @@
 
 ## Fixed
 
+- Fixed `OB-400-DOP-101503` (v4.0) and `OB-301-DOP-1015003` (v3.1) sending `Content-Type: text/plain` instead of `application/json` when posting the negative standing order consent payload, causing ASPSPs to respond with HTTP 415 instead of the expected HTTP 400.
 - Fixed incorrect test case ID references in v1.9.6 release notes from `OB-400-DOP-1015003` to `OB-400-DOP-101503`
 
 ## [1.9.7] - 05/03/2026

--- a/manifests/ob_3.1_payment_fca.json
+++ b/manifests/ob_3.1_payment_fca.json
@@ -598,6 +598,9 @@
         "postData": "$failingMinimalDomesticStandingOrderConsentV3",
         "requestConsent": "false"
       },
+      "headers": {
+        "Content-Type": "application/json"
+      },
       "body": "$postData",
       "uri": "/domestic-standing-order-consents",
       "uriImplementation": "conditional",

--- a/manifests/ob_4.0_payment_fca.json
+++ b/manifests/ob_4.0_payment_fca.json
@@ -583,6 +583,9 @@
           "postData": "$failingMinimalDomesticStandingOrderConsentV4",
           "requestConsent": "false"
         },
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "body": "$postData",
         "uri": "/domestic-standing-order-consents",
         "uriImplementation": "conditional",


### PR DESCRIPTION
## Summary

Fixes a bug reported via support ticket where test cases `OB-400-DOP-101503` (v4.0) and `OB-301-DOP-1015003` (v3.1) were sending `Content-Type: text/plain` instead of `application/json` for their POST requests to `/domestic-standing-order-consents`.

This caused ASPSP implementations to respond with **HTTP 415 Unsupported Media Type** instead of the expected **HTTP 400 Bad Request**, resulting in a false test failure.

## Root Cause

These two negative-test cases use `requestConsent: false`, which bypasses the payment consent acquisition flow that explicitly sets `Content-Type: application/json`. Unlike all other POST test cases in the payments module, they had no `headers` block in the manifest.

## Changes

- `manifests/ob_4.0_payment_fca.json` — added `Content-Type: application/json` header to `OB-400-DOP-101503`
- `manifests/ob_3.1_payment_fca.json` — added `Content-Type: application/json` header to `OB-301-DOP-1015003`
- `docs/releases/releases.md` — changelog entry added under `[Unreleased]`

## Testing

Confirmed by the reporter that the request was being sent as `text/plain`. Fix aligns these test cases with all other POST tests in the payment module (e.g. `OB-400-DOP-101400`, `OB-400-DOP-101401`) which already carry the explicit header.