### PR TITLE
Fix type of TestCase

### DIFF
--- a/pkg/client/handlers.go
+++ b/pkg/client/handlers.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+
 	"github.com/pkg/errors"
 )
 
@@ -59,9 +60,9 @@ type TestCaseResult struct {
 
 // TestCase result for a run
 type TestCase struct {
-	Id   string `json:"id"`
-	Pass bool   `json:"pass"`
-	Fail string `json:"fail,omitempty"`
+	Id   string   `json:"id"`
+	Pass bool     `json:"pass"`
+	Fail []string `json:"fail,omitempty"`
 }
 
 type event struct {


### PR DESCRIPTION
Issue: 
When running the conformance test suite from the CLI using `./fcs`, the results are not output correctly if there are any failures alongside test passes

The fix: 
`TestCase` in `handlers.go` should correspond to the `TestCase` in in [result.go](https://github.com/OpenBankingUK/conformance-suite/blob/0238706381326f040797991c3ae8926483251d87/pkg/executors/results/result.go#L8) which is `Fail       []string json:"fail,omitempty"`

How to test: 
Run test suite using the CLI tool using your preferred config, where you know at least one test will fail, eg
```
./fcs run \   
    --filename dummy-v3.1.8.json \
    --config test-failing-config.json \
    --export export-config.json
```

Before this change you should see that the output of the above command would fail to output any failing test results. After this change you should see that failing test results are output correctly with the failure message along with any passes 