### PR TITLE
Improve desktop PSU consent popup size

### DIFF
--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -9,6 +9,10 @@
 - Updated v4.0 standing order consent test `OB-400-DOP-101503` to reject `Frequency.CountPerPeriod` with `Frequency.PointInTime`, rather than rejecting valid bounded schedules that use `Frequency.CountPerPeriod` with `FinalPaymentDateTime`.
 - Reinstated v3.1 standing order response guard `OB-301-DOP-1015002`, which fails when `FinalPaymentAmount` is present without either `NumberOfPayments` or `FinalPaymentDateTime`.
 
+### Changed
+
+- Increased the desktop PSU consent authorization popup to a larger 900px by 900px target size, with screen-size clamping, to improve Ozone model bank viewing during consent flows.
+
 ### Added
 
 - Added optional `v4_standing_order_frequency` config/UI support for v4 standing-order success payloads. It defaults to `Type` `WEEK` and `PointInTime` `03`, remains separate from v3 `payment_frequency`, and discovery conditional properties still override matching request-body paths after defaults are applied.

--- a/docs/releases/v1.10.0.md
+++ b/docs/releases/v1.10.0.md
@@ -9,6 +9,10 @@ This release incorporates the following changes:
 - Updated v4.0 standing order consent test `OB-400-DOP-101503` to reject `Frequency.CountPerPeriod` with `Frequency.PointInTime`, rather than rejecting valid bounded schedules that use `Frequency.CountPerPeriod` with `FinalPaymentDateTime`.
 - Reinstated v3.1 standing order response guard `OB-301-DOP-1015002`, which fails when `FinalPaymentAmount` is present without either `NumberOfPayments` or `FinalPaymentDateTime`.
 
+## Changed
+
+- Increased the desktop PSU consent authorization popup to a larger 900px by 900px target size, with screen-size clamping, to improve Ozone model bank viewing during consent flows.
+
 ## Added
 
 - Added optional `v4_standing_order_frequency` config/UI support for v4 standing-order success payloads. It defaults to `Type` `WEEK` and `PointInTime` `03`, remains separate from v3 `payment_frequency`, and discovery conditional properties still override matching request-body paths after defaults are applied.

--- a/web/src/components/Wizard/TestCases/SpecificationHeader.vue
+++ b/web/src/components/Wizard/TestCases/SpecificationHeader.vue
@@ -69,6 +69,10 @@ const {
   mapState,
 } = createNamespacedHelpers('testcases');
 
+const PSU_CONSENT_POPUP_WIDTH = 900;
+const PSU_CONSENT_POPUP_HEIGHT = 900;
+const POPUP_SCREEN_MARGIN = 40;
+
 export default {
   name: 'SpecificationHeader',
   props: {
@@ -179,7 +183,7 @@ export default {
       const tokenName = this.tokenName(consentUrl);
 
       if (!this.mobileConsent) {
-        this.openPopup(consentUrl, 'PSU Consent', 1074 * 0.75, 800 * 0.75);
+        this.openPopup(consentUrl, 'PSU Consent', PSU_CONSENT_POPUP_WIDTH, PSU_CONSENT_POPUP_HEIGHT);
         return;
       }
 
@@ -306,10 +310,12 @@ export default {
       const height = (window.innerHeight ? window.innerHeight : clientHeight) + 15;
 
       const systemZoom = width / window.screen.availWidth;
-      const left = (width - w) / 2 / (systemZoom + dualScreenLeft);
-      const top = (height - h) / 2 / (systemZoom + dualScreenTop);
+      const popupWidth = Math.min(w, (window.screen.availWidth * systemZoom) - POPUP_SCREEN_MARGIN);
+      const popupHeight = Math.min(h, (window.screen.availHeight * systemZoom) - POPUP_SCREEN_MARGIN);
+      const left = (width - popupWidth) / 2 / (systemZoom + dualScreenLeft);
+      const top = (height - popupHeight) / 2 / (systemZoom + dualScreenTop);
 
-      const wLocation = `width=${w / systemZoom}, height=${h / systemZoom}, top=${top}, left=${left}`;
+      const wLocation = `width=${popupWidth / systemZoom}, height=${popupHeight / systemZoom}, top=${top}, left=${left}`;
       const wParams = `scrollbars=yes, ${wLocation}`;
       const newWindow = window.open(url, title, wParams);
 


### PR DESCRIPTION
Desktop PSU consent authorization currently opens in a small popup that makes the Ozone model bank consent pages feel cramped, especially for desktop account/payment selection flows.

This updates the desktop PSU consent popup to request a 900px by 900px target size while keeping scrollbars enabled and clamping the requested dimensions to the available screen size. The clamp preserves compatibility with smaller laptop displays while giving larger desktop screens a more useful viewing area.

The 1.10 release notes have also been updated to document the user-visible popup sizing change.

Validation:
- `cd web && npm run lint -- --no-fix`
- `cd web && npm run build`