### PR TITLE
Prepare v1.10.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To provide feedback, please see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release Notes
 
-### v1.10.0 - 2026-07-14
+### v1.10.0 - 2026-08-13
 
 [Full Release Notes](https://github.com/OpenBankingUK/conformance-suite/blob/develop/docs/releases/releases.md)
 
@@ -29,18 +29,18 @@ To provide feedback, please see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Version table
 
-| Release      | Standard version                                                                               |
-| ------------ | ---------------------------------------------------------------------------------------------- |
-| v1.10.0      | v4.0.1                                                                                         |
-| v1.9.7       | <ul><li>v4.0.0 - Swagger Update 5</li><li>cVRP (based on OBL 4.0.0 Swagger Update 4)</li></ul> |
-| v1.9.6       | <ul><li>v4.0.0 - Swagger Update 5</li><li>cVRP (based on OBL 4.0.0 Swagger Update 4)</li></ul> |
-| v1.9.5       | v4.0.0 - Swagger Update 4                                                                      |
-| v1.9.2       | v4.0.0 - Swagger Update 3                                                                      |
-| v1.9.0       | v4.0.0 - Swagger Update 2                                                                      |
-| v1.8.0       | v4.0.0                                                                                         |
-| v1.7.6       | v3.1.11                                                                                        |
-| v1.7.0       | v3.1.10                                                                                        |
-| v1.6.12      | v3.1.9                                                                                         |
+| Release | Standard version |
+| --- | --- |
+| v1.10.0 | v4.0.1 |
+| v1.9.7 | <ul><li>v4.0.0 - Swagger Update 5</li><li>cVRP (based on OBL 4.0.0 Swagger Update 4)</li></ul> |
+| v1.9.6 | <ul><li>v4.0.0 - Swagger Update 5</li><li>cVRP (based on OBL 4.0.0 Swagger Update 4)</li></ul> |
+| v1.9.5 | v4.0.0 - Swagger Update 4 |
+| v1.9.2 | v4.0.0 - Swagger Update 3 |
+| v1.9.0 | v4.0.0 - Swagger Update 2 |
+| v1.8.0 | v4.0.0 |
+| v1.7.6 | v3.1.11 |
+| v1.7.0 | v3.1.10 |
+| v1.6.12 | v3.1.9 |
 
 ## Quickstart
 

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,12 +1,14 @@
 package main
 
 import (
-	"github.com/OpenBankingUK/conformance-suite/pkg/client"
 	"fmt"
+
+	"github.com/OpenBankingUK/conformance-suite/pkg/client"
+	suiteVersion "github.com/OpenBankingUK/conformance-suite/pkg/version"
 	"github.com/spf13/cobra"
 )
 
-const cliVersion = "0.0.1"
+const cliVersion = suiteVersion.FullVersion
 
 func versionCmd(service client.Service) *cobra.Command {
 	return &cobra.Command{

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -1793,8 +1793,8 @@ _EMPTY BODY_
   },
   "examples": [
     {
-      "version": "v1.9.1",
-      "message": "Conformance Suite is running the latest version v1.9.1",
+      "version": "v1.10.0",
+      "message": "Conformance Suite is running the latest version v1.10.0",
       "update": false
     }
   ]

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -1,6 +1,6 @@
 # Release history
 
-## [1.10.0] - 14/07/2026
+## [1.10.0] - 13/08/2026
 
 ### Fixed
 
@@ -511,7 +511,10 @@ v3.1 of the OBIE Accounts and Transactions specifications and Payments.
 ---
 
 [More Releases](docs/releases)
-[Unreleased]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.8-beta1...HEAD
+[Unreleased]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.9...v1.10.0
+[1.9.9]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.8...v1.9.9
+[1.9.8]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.8-beta1...v1.9.8
 [1.9.8-beta1]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.7...v1.9.8-beta1
 [1.9.7]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.7-beta1...v1.9.7
 [1.9.7-beta1]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.6...v1.9.7-beta1

--- a/docs/releases/v1.10.0.md
+++ b/docs/releases/v1.10.0.md
@@ -1,4 +1,4 @@
-# Release v1.10.0 (14th July 2026)
+# Release v1.10.0 (13th August 2026)
 
 This release incorporates the following changes:
 


### PR DESCRIPTION
Prepare the release branch for v1.10.0 by aligning the release-facing version metadata and documentation with the final release details.

## Changes

- Set the v1.10.0 release date to 13 August 2026 in the README and release notes.
- Update the version endpoint API docs example to report v1.10.0.
- Make the CLI version reuse the suite version constant so it stays aligned with the server release version.
- Update changelog compare links so v1.10.0 is treated as the latest release.
- Keep v4.0.1 documented as the latest standard version for v1.10.0.

## Tests

- `make test`
- `cd web && yarn test:unit --runInBand`