### PR TITLE
Fix PRO-103403 products endpoint for v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ To provide feedback, please see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release Notes
 
-### v1.10.0 - 2026-08-13
+### v1.11.0 - TBD
 
 [Full Release Notes](https://github.com/OpenBankingUK/conformance-suite/blob/develop/docs/releases/releases.md)
 
 ---
 **Download**:
-`docker run --rm -it -p 127.0.0.1:8443:8443 "openbanking/conformance-suite:v1.10.0"` |
+`docker run --rm -it -p 127.0.0.1:8443:8443 "openbanking/conformance-suite:v1.11.0"` |
 [DockerHub](https://hub.docker.com/r/openbanking/conformance-suite) |
 [Setup Guide](https://github.com/OpenBankingUK/conformance-suite/blob/develop/docs/setup-guide.md)
 ---
@@ -31,7 +31,7 @@ To provide feedback, please see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 | Release | Standard version |
 | --- | --- |
-| v1.10.0 | v4.0.1 |
+| v1.11.0 | v4.0.1 (standard) |
 | v1.9.7 | <ul><li>v4.0.0 - Swagger Update 5</li><li>cVRP (based on OBL 4.0.0 Swagger Update 4)</li></ul> |
 | v1.9.6 | <ul><li>v4.0.0 - Swagger Update 5</li><li>cVRP (based on OBL 4.0.0 Swagger Update 4)</li></ul> |
 | v1.9.5 | v4.0.0 - Swagger Update 4 |
@@ -46,11 +46,11 @@ To provide feedback, please see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Pull and run the latest (stable) tagged Docker image:
 
-    > docker run --rm -it -p 127.0.0.1:8443:8443 "openbanking/conformance-suite:v1.10.0"
+    > docker run --rm -it -p 127.0.0.1:8443:8443 "openbanking/conformance-suite:v1.11.0"
 
 or
 
-    > docker run --rm -it -p 8443:8443 "openbanking/conformance-suite:v1.10.0"
+    > docker run --rm -it -p 8443:8443 "openbanking/conformance-suite:v1.11.0"
 [See Setup Guide](https://github.com/OpenBankingUK/conformance-suite/blob/develop/docs/setup-guide.md)
 
 ### Prerequisites

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -1793,8 +1793,8 @@ _EMPTY BODY_
   },
   "examples": [
     {
-      "version": "v1.10.0",
-      "message": "Conformance Suite is running the latest version v1.10.0",
+      "version": "v1.11.0",
+      "message": "Conformance Suite is running the latest version v1.11.0",
       "update": false
     }
   ]

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -1,5 +1,11 @@
 # Release history
 
+## [1.11.0] - TBD
+
+### Fixed
+
+- Corrected Product playback tests `OB-301-PRO-103403` and `OB-400-PRO-103403` to target the valid bulk Products endpoint `/products` instead of `/product`. This may cause the x-fapi-interaction-id playback check to run where it was previously skipped by discovery filtering.
+
 ## [1.10.0] - 13/08/2026
 
 ### Fixed
@@ -511,7 +517,8 @@ v3.1 of the OBIE Accounts and Transactions specifications and Payments.
 ---
 
 [More Releases](docs/releases)
-[Unreleased]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.9...v1.10.0
 [1.9.9]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.8...v1.9.9
 [1.9.8]: https://github.com/OpenBankingUK/conformance-suite/compare/v1.9.8-beta1...v1.9.8

--- a/docs/releases/v1.11.0.md
+++ b/docs/releases/v1.11.0.md
@@ -1,0 +1,13 @@
+# Release v1.11.0 (TBD)
+
+This release incorporates the following changes:
+
+## Fixed
+
+- Corrected Product playback tests `OB-301-PRO-103403` and `OB-400-PRO-103403` to target the valid bulk Products endpoint `/products` instead of `/product`. This may cause the x-fapi-interaction-id playback check to run where it was previously skipped by discovery filtering.
+
+## Download
+
+`docker run --rm -it -p 8443:8443 "openbanking/conformance-suite:v1.11.0"` |
+[DockerHub](https://hub.docker.com/r/openbanking/conformance-suite) |
+[Setup Guide](https://github.com/OpenBankingUK/conformance-suite/blob/develop/docs/setup-guide.md)

--- a/manifests/ob_3.1_accounts_transactions_fca.json
+++ b/manifests/ob_3.1_accounts_transactions_fca.json
@@ -1492,7 +1492,7 @@
       "headers": {
         "x-fapi-interaction-id": "$x-fapi-interaction-id"
       },
-      "uri": "/product",
+      "uri": "/products",
       "uriImplementation": "optional",
       "resource": "Product",
       "method": "get",

--- a/manifests/ob_4.0_accounts_transactions_fca.json
+++ b/manifests/ob_4.0_accounts_transactions_fca.json
@@ -1473,7 +1473,7 @@
         "headers": {
           "x-fapi-interaction-id": "$x-fapi-interaction-id"
         },
-        "uri": "/product",
+        "uri": "/products",
         "uriImplementation": "optional",
         "resource": "Product",
         "method": "get",

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -318,3 +318,34 @@ func TestUnMappedManifestItemsReportedCorrectly(t *testing.T) {
 
 	require.Equal(exp, unmatched)
 }
+
+func TestProductPlaybackTestUsesBulkProductsEndpoint(t *testing.T) {
+	require := test.NewRequire(t)
+
+	testCases := []struct {
+		manifestPath string
+		testID       string
+	}{
+		{"file://manifests/ob_3.1_accounts_transactions_fca.json", "OB-301-PRO-103403"},
+		{"file://manifests/ob_4.0_accounts_transactions_fca.json", "OB-400-PRO-103403"},
+	}
+
+	for _, tc := range testCases {
+		scripts, err := LoadScripts(tc.manifestPath)
+		require.Nil(err)
+
+		found := false
+		for _, script := range scripts.Scripts {
+			if script.ID != tc.testID {
+				continue
+			}
+
+			found = true
+			require.Equal("/products", script.URI)
+			require.Equal("get", script.Method)
+			require.Equal("optional", script.URIImplemenation)
+		}
+
+		require.True(found)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,9 +22,9 @@ const (
 	// Checker must conform to the format expected, major, minor and patch.
 	// @NEW-SPEC-RELEASE - make sure new version is accounted for
 	// @NEW-RELEASE - make sure new version is accounted for
-	//v1.10.0 - this comment allows searching
+	//v1.11.0 - this comment allows searching
 	major = "1"
-	minor = "10"
+	minor = "11"
 	patch = "0"
 
 	//FullVersion - Checker is the full string version of Conformance Suite.

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -74,7 +74,7 @@ func TestNoUpdateUpdateWarningVersionForDoubleDigitMinor(t *testing.T) {
 
 	v := NewGitHub(serverURL)
 
-	message, flag, err := v.UpdateWarningVersion("v1.10.0")
+	message, flag, err := v.UpdateWarningVersion("v1.11.0")
 
 	require.NoError(t, err)
 	assert.Equal(t, false, flag)


### PR DESCRIPTION
## Summary
- correct PRO-103403 Product playback tests to call the bulk `/products` endpoint
- bump the suite version to v1.11.0 and add release notes
- update README/API docs version references

## Validation
- go test ./pkg/manifest ./pkg/version